### PR TITLE
add subject metadata to upload

### DIFF
--- a/subject_set_upload.py
+++ b/subject_set_upload.py
@@ -43,6 +43,7 @@ def upload_subject(file, project_id):
     s = Subject()
     s.links.project = project_id
     s.add_location(file)
+    s.metadata.update({'filename': file})
     s.save()
     return s
   except Exception as e:


### PR DESCRIPTION
Based on our previous conversation and follow-up from Sam, this PR suggests a small edit to your subject uploading script so that the filename of the source file (i.e., the subject image) is written to subject metadata.  For context, this behavior mimics that of the drag-and-drop upload interface built into the project builder, which writes the source filename as a single key-value pair in the subject metadata. As this metadata is not added automatically as part of the subject creation / upload process, I've added the single line of code necessary to do so as part of your Python client script.

Please note: this is a simple and extendable edit -- you could always write additional key-value pairs to metadata rather than just writing the filename.  To do so, simply add additional keys to the dictionary that is passed to the `subject.metadata.update()` command.